### PR TITLE
Don't throw 404 on OPTIONS requests

### DIFF
--- a/handleError.js
+++ b/handleError.js
@@ -19,7 +19,7 @@ const handleError = onError => {
 
   return (context, next) => next()
     .then(() => {
-      if (context.body === undefined) {
+      if (context.body === undefined && context.request.method !== 'OPTIONS') {
         context.status = NOTFOUND_STATUS;
         context.body = NOTFOUND_BODY;
       }


### PR DESCRIPTION
OPTIONS requests have an empty body, but information in the header (`Accept`), therefore, handleErrors shouldn't throw a 404.